### PR TITLE
v2.0.0 added `/version` endpoint

### DIFF
--- a/eddb_jsonapi/__init__.py
+++ b/eddb_jsonapi/__init__.py
@@ -8,6 +8,8 @@ import pyramid_jsonapi
 from pyramid_beaker import set_cache_regions_from_settings
 from pyramid_beaker import session_factory_from_settings
 
+__version__ = "2.0.0"
+
 
 def request_factory(environ):
     request = Request(environ)
@@ -42,6 +44,7 @@ def main(global_config, **settings):
     config.add_route('search', '/search')
     config.add_route('landmark', '/landmark')
     config.add_route('mecha', '/mecha')
+    config.add_route('version', '/version')
     config.set_request_factory(request_factory)
     pj = pyramid_jsonapi.PyramidJSONAPI(config, edsmmodels, lambda view: edsmmodels.DBSession)
     pj.create_jsonapi_using_magic_and_pixie_dust()

--- a/eddb_jsonapi/views/version.py
+++ b/eddb_jsonapi/views/version.py
@@ -1,0 +1,18 @@
+from pyramid.view import (
+    view_config
+)
+
+from .. import __version__
+
+
+@view_config(route_name='version', renderer="json")
+def version(request):
+    return {
+        'data': {
+            'type': 'version',
+            'id': 1,
+            'attributes': {
+                'version': __version__
+            }
+        }
+    }

--- a/setup.py
+++ b/setup.py
@@ -15,18 +15,29 @@ requires = [
     'pyramid_debugtoolbar',
     'waitress',
     'sqlalchemy',
-    'zope.sqlalchemy', 'requests', 'odo', 'wsgicors', 'pyramid_jsonapi',
-    'psycopg2', 'odo', 'pyramid_beaker', 'aiopyramid', 'gunicorn', 'ijson', 'transaction'
-    ]
+    # FIXME https://github.com/zopefoundation/zope.sqlalchemy/blob/master/CHANGES.rst#12-2019-10-17
+    'zope.sqlalchemy<1.2',
+    'requests',
+    'odo',
+    'wsgicors',
+    'pyramid_jsonapi',
+    'psycopg2',
+    'odo',
+    'pyramid_beaker',
+    'aiopyramid',
+    'gunicorn',
+    'ijson',
+    'transaction'
+]
 
 tests_require = [
     'WebTest >= 1.3.1',  # py3 compat
     'pytest',  # includes virtualenv
     'pytest-cov',
-    ]
+]
 
 setup(name='EDDB_JsonAPI',
-      version='0.1',
+      version='2.0.0',
       description='EDDB_JsonAPI',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
It was raised to my attention this project has had a major release, and downstream clients don't have a means of checking what version of this API they are actually talking to.

## New endpoints
`/version` draws from module's `__version__` declaration, see [PEP 396](https://www.python.org/dev/peps/pep-0396/). AFAICS the object returned is JSONAPI compliant.

## Other changes made
- bumped `setup.py`'s version identifier, this is at least the second major version of the API so `v0.0.0` doesn't fit.
- pinned down `zope.sqlalchemy`  due to [breaking changes in a point release](https://github.com/zopefoundation/zope.sqlalchemy/blob/master/CHANGES.rst#12-2019-10-17) 😒