### PR TITLE
Add system ID to `/search` perfect match

### DIFF
--- a/eddb_jsonapi/views/search.py
+++ b/eddb_jsonapi/views/search.py
@@ -90,7 +90,7 @@ def search(request):
         idjitresult = DBSession.query(System).filter(System.name == name)
         if idjitresult.count() > 0:
             for candidate in idjitresult:
-                candidates.append({'name': candidate.name, 'similarity': 'Perfect match'})
+                candidates.append({'name': candidate.name, 'similarity': 'Perfect match', 'id': candidate.id})
             return {'meta': {'name': name, 'type': 'Perfect match'}, 'data': candidates}
         # Carry on.
         result = DBSession.execute(sql)


### PR DESCRIPTION
This change adds the system ID to the results of `/search` in the case that the searched system finds a perfect match.